### PR TITLE
Using attached_terget_group with -parallelism instead of GRPC calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,20 +41,20 @@ subnet_ids = [
 ]
 ```
 
-#### Вызов терраформа
+### Вызов терраформа
+
+Использование параметра -parallelism=1 является обязательным.
 
 ```bash
 terraform init
 terraform plan
-terraform apply
+terraform apply -parallelism=1
 ```
 
-## Удаляем инфраструктуру
-## Из-за особенности работы NLB с target VM удаление инфраструктуры необходимо запускать несколько раз, по количеству натируемых эндпойнтов
+### Удаляем инфраструктуру
 
 ```bash
-terraform destroy
-terraform destroy
-terraform destroy
-terraform destroy
+terraform destroy -parallelism=1
 ```
+
+В результате работы плейбука будет сформирован и загружен в S3 бакет .sh файл, который необходимо использовать в качестве init скрипта кластеров Data Proc.

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -25,9 +25,7 @@ resource "yandex_lb_network_load_balancer" "this" {
       subnet_id = length(var.subnet_ids) == 0 ? yandex_vpc_subnet.this[0].id : var.subnet_ids[0]
     }
   }
- 
-  # Those operations become blocked on target group object if it is the same for all balancers. Using GRPC API in local_exec instead.
-  
+
   attached_target_group {
     target_group_id = yandex_lb_target_group.this.id
 
@@ -42,12 +40,4 @@ resource "yandex_lb_network_load_balancer" "this" {
       }
     }
   }
-  
-/*
-  provisioner "local-exec" {
-    command = <<-CMD
-    sleep ${count.index * 30} && curl -s -d '{ attachedTargetGroup: { targetGroupId: "${yandex_lb_target_group.this.id}", healthChecks: [{ name: "custom", interval: "30s", timeout: "10s", unhealthyThreshold: 2, healthyThreshold: 2, tcpOptions: {port: ${var.yc_endpoints_struct[count.index].port}} }] }}' -H "Authorization: Bearer $YC_TOKEN" -X POST https://load-balancer.api.cloud.yandex.net/load-balancer/v1/networkLoadBalancers/${self.id}:attachTargetGroup
-    CMD
-  }
-*/
 }

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -27,7 +27,7 @@ resource "yandex_lb_network_load_balancer" "this" {
   }
  
   # Those operations become blocked on target group object if it is the same for all balancers. Using GRPC API in local_exec instead.
-  /*
+  
   attached_target_group {
     target_group_id = yandex_lb_target_group.this.id
 
@@ -35,18 +35,19 @@ resource "yandex_lb_network_load_balancer" "this" {
       name = "custom"
       interval = 300
       timeout = 10
-      unhealthy_threshold = 1
-      healthy_threshold = 1
+      unhealthy_threshold = 2
+      healthy_threshold = 2
       tcp_options {
         port = var.yc_endpoints_struct[count.index].port
       }
     }
   }
-*/
-
+  
+/*
   provisioner "local-exec" {
     command = <<-CMD
     sleep ${count.index * 30} && curl -s -d '{ attachedTargetGroup: { targetGroupId: "${yandex_lb_target_group.this.id}", healthChecks: [{ name: "custom", interval: "30s", timeout: "10s", unhealthyThreshold: 2, healthyThreshold: 2, tcpOptions: {port: ${var.yc_endpoints_struct[count.index].port}} }] }}' -H "Authorization: Bearer $YC_TOKEN" -X POST https://load-balancer.api.cloud.yandex.net/load-balancer/v1/networkLoadBalancers/${self.id}:attachTargetGroup
     CMD
   }
+*/
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "dp_init_script" {
-  description = "Use this S3 object as init script for ypur Data Proc clusters"
+  description = "Use this S3 object as init script for your Data Proc clusters"
   value = "s3a://${yandex_storage_bucket.this.bucket}/${yandex_storage_object.this.key}"
 }


### PR DESCRIPTION
Using attached_terget_group with -parallelism instead of GRPC calls